### PR TITLE
Make api constructor return errors.

### DIFF
--- a/lib/inwx.js
+++ b/lib/inwx.js
@@ -17,8 +17,9 @@ var xmlrpc = require('xmlrpc');
  * init inwx api and call readyCallback when ready
  * @param opts            {api: production|testing, user: string, password: string}
  * @param readyCallback   call when api is ready
+ * @param errorCallback   call on error (optional)
  */
-function inwx(opts, readyCallback) {
+function inwx(opts, readyCallback, errorCallback) {
   this.connected = false;
   var that = this;
 
@@ -32,10 +33,18 @@ function inwx(opts, readyCallback) {
 
   this.client = xmlrpc.createSecureClient({ host: opts.host, path: "/xmlrpc/", cookies: true });
 
-  this.call("account", "login", {user: opts.user, pass: opts.password}, function(response) {
-    this.connected = true;
-    readyCallback.call(this, that);
-  });
+  this.call("account", "login", {user: opts.user, pass: opts.password},
+    function(response) {
+      this.connected = true;
+      readyCallback.call(this, that);
+    },
+    function (error) {
+      if(errorCallback) {
+        errorCallback.call(this, error);
+      } else {
+        throw new Error(error.msg);
+      }
+    });
 
   return that;
 }
@@ -71,6 +80,7 @@ inwx.prototype.call = function call(object, method, params, successCallback, err
         } else {
           var additionalReason = response.reason ? " + " + response.reason + "(AdditionalCode " + response.reasonCode + ")": "";
           console.error("ERROR: " + object + "." + method + "(" + JSON.stringify(params) + ") returned: " + response.msg + " (Code " + response.code + ")" + (additionalReason ? additionalReason : ""));
+          throw new Error(response.msg);
         }
       }
     }


### PR DESCRIPTION
Currently, the api constructor only returns an api object on successful logins but does nothing when the logins fails (e.g. when submitting an invalid password), so there is no way of handling errors during api-setup.

This pull request adds 2 changes to fix this:
- When no error-callback is passed to `call()` it throws an `Error()` instead of just logging to console.
- The constructor gets an optional error-callback which is called if the login fails. If no callback is defined, it throws an `Error()`.
